### PR TITLE
Fix camel_case no long available in laravel

### DIFF
--- a/src/Utils/Model.php
+++ b/src/Utils/Model.php
@@ -2,6 +2,8 @@
 
 namespace LasseRafn\Economic\Utils;
 
+use Illuminate\Support\Str;
+
 class Model
 {
     protected $entity;
@@ -20,7 +22,7 @@ class Model
         $data = (array) $data;
 
         foreach ($data as $key => $value) {
-            $customSetterMethod = 'set'.ucfirst(camel_case($key)).'Attribute';
+            $customSetterMethod = 'set'.ucfirst(Str::camel($key)).'Attribute';
 
             if (!method_exists($this, $customSetterMethod)) {
                 $this->setAttribute($key, $value);


### PR DESCRIPTION
Since laravel 5.7 camel_case method is moved into Str helper class