### PR TITLE
Fix array_only no long available in laravel

### DIFF
--- a/src/Utils/Model.php
+++ b/src/Utils/Model.php
@@ -3,6 +3,7 @@
 namespace LasseRafn\Economic\Utils;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 
 class Model
 {
@@ -61,7 +62,7 @@ class Model
     public function toPutArray($overrides = [])
     {
         if (isset($this->puttable)) {
-            return array_merge(array_only(
+            return array_merge(Arr::only(
                 $this->toArray(),
                 $this->puttable
             ), $overrides);


### PR DESCRIPTION
Same as #26

Since laravel 5.7 array_only method is moved into Arr helper class